### PR TITLE
Adding perceptional precision support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/alexey1312/SnapshotTestingHEIC.git",
         "state": {
           "branch": null,
-          "revision": "cfdfdd431e3f7b272faa935fa0d1c1707839d443",
-          "version": "1.1.0"
+          "revision": "a282334d83b536212fc1a074f0a5a241256718f0",
+          "version": "1.2.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SnapshotTestingStitch",
     platforms: [
-        .iOS(.v11),
+        .iOS(.v13),
     ],
     products: [
         .library(

--- a/Sources/SnapshotTestingStitch/Snapshotting.swift
+++ b/Sources/SnapshotTestingStitch/Snapshotting.swift
@@ -12,12 +12,14 @@ public extension Snapshotting where Format == UIImage {
     ///     including but not limited to the item spacing, and optional image borders.
     ///   - precision: The percentage of pixels that must match in the final comparison
     ///   in order for the test to successfully pass.
+    ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
     ///   - format: The desired image format to use when writing to an image destination.
     ///   It would default to PNG for backwards compatibility.
     static func stitch(
         strategies tasks: [Snapshotting<Value, Format>],
         style: StitchStyle = .init(),
         precision: Float = 1,
+        perceptualPrecision: Float = 1,
         format: ImageFormat = .png
     ) -> Snapshotting {
         // Default to an empty string, if they choose not to provide one.
@@ -25,6 +27,7 @@ public extension Snapshotting where Format == UIImage {
             strategies: tasks.map { .init(name: nil, strategy: $0, configure: nil) },
             style: style,
             precision: precision,
+            perceptualPrecision: perceptualPrecision,
             format: format
         )
     }
@@ -39,18 +42,21 @@ public extension Snapshotting where Format == UIImage {
     ///   including but not limited to the item spacing, and optional image borders.
     ///   - precision: The percentage of pixels that must match in the final comparison
     ///   in order for the test to successfully pass.
+    ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
     ///   - format: The desired image format to use when writing to an image destination.
     ///   It would default to PNG for backwards compatibility.
     static func stitch(
         strategies tasks: [(name: String, strategy: Snapshotting<Value, Format>)],
         style: StitchStyle = .init(),
         precision: Float = 1,
+        perceptualPrecision: Float = 1,
         format: ImageFormat = .png
     ) -> Snapshotting {
         stitch(
             strategies: tasks.map { .init(name: $0.name, strategy: $0.strategy, configure: nil) },
             style: style,
             precision: precision,
+            perceptualPrecision: perceptualPrecision,
             format: format
         )
     }
@@ -67,19 +73,21 @@ public extension Snapshotting where Format == UIImage {
     ///   including but not limited to the item spacing, and optional image borders.
     ///   - precision: The percentage of pixels that must match in the final comparison
     ///   in order for the test to successfully pass.
+    ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
     ///   - format: The desired image format to use when writing to an image destination.
     ///   It would default to PNG for backwards compatibility.
     static func stitch(
         strategies tasks: [StitchTask<Value, Format>],
         style: StitchStyle = .init(),
         precision: Float = 1,
+        perceptualPrecision: Float = 1,
         format: ImageFormat = .png
     ) -> Snapshotting {
         let internalStrategy: Snapshotting<UIViewController, UIImage>
 
         switch format {
             case .png:
-                internalStrategy = .image(precision: precision)
+                internalStrategy = .image(precision: precision, perceptualPrecision: perceptualPrecision)
             case .heic(let compressionQuality):
                 internalStrategy = .imageHEIC(precision: precision, compressionQuality: compressionQuality)
         }


### PR DESCRIPTION
This PR adds support for the great work that Eric has completed: https://github.com/pointfreeco/swift-snapshot-testing/pull/628

png support only for now. I'll be working on updating the HEIC library next.