### PR TITLE
Fix minimum platform version to match the requirement of swift-snapshot-testing

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/alexey1312/SnapshotTestingHEIC.git",
         "state": {
           "branch": null,
-          "revision": "cfdfdd431e3f7b272faa935fa0d1c1707839d443",
-          "version": "1.1.0"
+          "revision": "a282334d83b536212fc1a074f0a5a241256718f0",
+          "version": "1.2.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SnapshotTestingStitch",
     platforms: [
-        .iOS(.v11),
+        .iOS(.v13),
     ],
     products: [
         .library(
@@ -20,7 +20,7 @@ let package = Package(
                  from: "1.10.0"),
         .package(name: "SnapshotTestingHEIC",
                  url: "https://github.com/alexey1312/SnapshotTestingHEIC.git",
-                 from: "1.1.0"),
+                 from: "1.2.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
swift-snapshot-testing package has increased minimum OS requirements in the latest version